### PR TITLE
TDL-18739: Update the value types of the config params

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The tap requires some fields to be completed in a config file in order to work. 
 - end_date: Date from which the tap ends extracting data. RFC3339 format. (Optional)
 - user_agent: User agent that makes the API call.
 - access_token: Access token for the TikTok Marketing API
-- accounts: A list of account ids.
+- accounts: A string containing comma-separated values of account ids.
 - request_timeout: The time for which request should wait to get response. It is an optional parameter and default value as 300 seconds.
 - sandbox (string, optional): Whether to communication with tiktok-ads's sandbox or business account for this application. If you're not sure leave out. Defaults to false.
 
@@ -41,7 +41,7 @@ The tap requires some fields to be completed in a config file in order to work. 
   "end_date": "2020-01-01T00:00:00Z",
   "user_agent": "tap-tiktok-ads <api_user_email@your_company.com>",
   "access_token": "YOUR_ACCESS_TOKEN",
-  "accounts": [],
+  "accounts": "id1, id2, id3",
   "sandbox": "<true|false>",
   "request_timeout": 300
 }
@@ -79,7 +79,7 @@ Create your tap's `config.json` file which should look like the following:
         "start_date": "2019-01-01T00:00:00Z",
         "user_agent": "tap-tiktok-ads <api_user_email@your_company.com>",
         "access_token": "YOUR_ACCESS_TOKEN",
-        "accounts": [id1, id2, id3],
+        "accounts": "id1, id2, id3",
         "request_timeout": 300
     }
     ```

--- a/sample_config.json
+++ b/sample_config.json
@@ -2,7 +2,7 @@
   "access_token": "your access token",
   "start_date": "2020-05-01T00:00:00Z",
   "user_agent": "user <email>",
-  "accounts": [123456789, 123124142],
+  "accounts": "123456789, 123124142",
   "sandbox": "true",
   "request_timeout": 300
 }

--- a/tap_tiktok_ads/__init__.py
+++ b/tap_tiktok_ads/__init__.py
@@ -17,8 +17,11 @@ def main():
 
     # get comma-separated string of accounts
     accounts = args.config['accounts'].replace(" ", "")
-    # create list of accounts
-    accounts_list = [int(i) for i in accounts.split(",")]
+    try:
+        # create list of accounts
+        accounts_list = [int(i) for i in accounts.split(",")]
+    except ValueError as e:
+        raise ValueError(str(e) + ". Please provide atleast 1 Account ID") from None
     # update string to list in the config
     args.config['accounts'] = accounts_list
 

--- a/tap_tiktok_ads/__init__.py
+++ b/tap_tiktok_ads/__init__.py
@@ -15,6 +15,13 @@ def main():
     # Parse command line arguments
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
 
+    # get comma-separated string of accounts
+    accounts = args.config['accounts'].replace(" ", "")
+    # create list of accounts
+    accounts_list = [int(i) for i in accounts.split(",")]
+    # update string to list in the config
+    args.config['accounts'] = accounts_list
+
     with TikTokClient(access_token=args.config['access_token'],
                       advertiser_id=args.config['accounts'],
                       sandbox=args.config.get('sandbox', False),

--- a/tap_tiktok_ads/__init__.py
+++ b/tap_tiktok_ads/__init__.py
@@ -17,11 +17,14 @@ def main():
 
     # get comma-separated string of accounts
     accounts = args.config['accounts'].replace(" ", "")
+    # raise error if no accounts is passed
+    if not accounts:
+        raise Exception("Please provide atleast 1 Account ID.")
     try:
         # create list of accounts
         accounts_list = [int(i) for i in accounts.split(",")]
-    except ValueError as e:
-        raise ValueError(str(e) + ". Please provide atleast 1 Account ID") from None
+    except ValueError:
+        raise Exception("Provided list of account IDs contains invalid IDs. Kindly check your Account IDs.") from None
     # update string to list in the config
     args.config['accounts'] = accounts_list
 

--- a/tap_tiktok_ads/discover.py
+++ b/tap_tiktok_ads/discover.py
@@ -14,7 +14,6 @@ def discover():
                 stream=stream_name,
                 schema=schema,
                 key_properties=STREAMS[stream_name].key_properties,
-                replication_key=STREAMS[stream_name].replication_keys,
                 metadata=mdata
             )
         )

--- a/tap_tiktok_ads/streams.py
+++ b/tap_tiktok_ads/streams.py
@@ -145,7 +145,8 @@ def transform_ad_insights_records(records):
     transformed_records = []
     for record in records:
         if 'metrics' in record and 'dimensions' in record:
-            transformed_record = record['metrics'] | record['dimensions']
+            # merging of 2 dicts by not using '|' for older python version compatibility
+            transformed_record = {**record['metrics'], **record['dimensions']}
             if 'secondary_goal_result' in transformed_record and transformed_record['secondary_goal_result'] == '-':
                 transformed_record['secondary_goal_result'] = None
             if 'cost_per_secondary_goal_result' in transformed_record and transformed_record[

--- a/tap_tiktok_ads/streams.py
+++ b/tap_tiktok_ads/streams.py
@@ -265,7 +265,7 @@ class Stream():
         """
             Process records for the stream by transforming it to the desired format, writing it to output, and bookmark writing
         """
-        bookmark_column = self.replication_keys[0]
+        bookmark_column = self.replication_keys[0] # pylint: disable=unsubscriptable-object
         bookmark_data = self.get_bookmark(stream.tap_stream_id)
         bookmark_value = get_bookmark_value(stream.tap_stream_id, bookmark_data, advertiser_id)
         transformed_records = pre_transform(stream.tap_stream_id, records, bookmark_value)

--- a/tap_tiktok_ads/streams.py
+++ b/tap_tiktok_ads/streams.py
@@ -265,7 +265,7 @@ class Stream():
         """
             Process records for the stream by transforming it to the desired format, writing it to output, and bookmark writing
         """
-        bookmark_column = stream.replication_key[0]
+        bookmark_column = self.replication_keys[0]
         bookmark_data = self.get_bookmark(stream.tap_stream_id)
         bookmark_value = get_bookmark_value(stream.tap_stream_id, bookmark_data, advertiser_id)
         transformed_records = pre_transform(stream.tap_stream_id, records, bookmark_value)

--- a/tests/base.py
+++ b/tests/base.py
@@ -44,7 +44,7 @@ class TiktokBase(unittest.TestCase):
         """Return config"""
         return_value = {
             "start_date": "2020-12-01T00:00:00Z",
-            "sandbox": True,
+            "sandbox": "true",
         }
         if original:
             return return_value

--- a/tests/base.py
+++ b/tests/base.py
@@ -37,7 +37,7 @@ class TiktokBase(unittest.TestCase):
         """Return creds from env variables"""
         return {
             "access_token": os.getenv("TAP_TIKTOK_ADS_ACCESS_TOKEN"),
-            "accounts": eval(os.getenv("TAP_TIKTOK_ADS_ACCOUNTS"))
+            "accounts": os.getenv("TAP_TIKTOK_ADS_ACCOUNTS")
         }
 
     def get_properties(self, original: bool = True):

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -31,7 +31,7 @@ class TiktokBookmarksTest(TiktokBase):
         - The number of records in the 2nd sync is less then the first
         """
         # get account id for collecting bookmark
-        account_id = eval(os.getenv("TAP_TIKTOK_ADS_ACCOUNTS"))[0]
+        account_id = os.getenv("TAP_TIKTOK_ADS_ACCOUNTS")
 
         conn_id = connections.ensure_connection(self)
         runner.run_check_mode(self, conn_id)

--- a/tests/unittests/test_accounts_list.py
+++ b/tests/unittests/test_accounts_list.py
@@ -65,3 +65,29 @@ class TestAccountsList(unittest.TestCase):
 
         # verify the comma-separated string of accounts is converted to list of accounts
         self.assertEqual(actual_config, expected_config)
+
+    @mock.patch("singer.utils.parse_args")
+    @mock.patch("tap_tiktok_ads.sync")
+    @mock.patch("tap_tiktok_ads.TikTokClient")
+    def test_empty_accounts_list(self, mocked_TikTokClient, mocked_sync, mocked_parse_args):
+
+        # create config file
+        config = {
+            "start_date": "2022-01-01T00:00:00Z",
+            "user_agent": "tap-tiktok-ads <api_user_email@your_company.com>",
+            "access_token": "test_access_token",
+            "accounts": ""
+        }
+
+        # mock TikTokClient
+        mocked_TikTokClient.side_effect = MockTikTokClient
+        # mock singer.parse_args
+        mocked_parse_args.return_value = get_args(config)
+
+        # verify we raise error when empty "accounts" is passed
+        with self.assertRaises(ValueError) as e:
+            # function call
+            main()
+
+        # verify the error message
+        self.assertTrue("Please provide atleast 1 Account ID" in str(e.exception))

--- a/tests/unittests/test_accounts_list.py
+++ b/tests/unittests/test_accounts_list.py
@@ -1,0 +1,67 @@
+import copy
+import unittest
+from unittest import mock
+from tap_tiktok_ads import main
+
+# mock TikTokClient class
+class MockTikTokClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+# mock singer.parse_args
+class MockParseArgs:
+    config = {}
+
+    def __init__(self, config):
+        self.config = config
+        self.catalog = {}
+        self.discover = False
+        self.state = {}
+
+# mock args and return desired value
+def get_args(config):
+    return MockParseArgs(config)
+
+class TestAccountsList(unittest.TestCase):
+    """
+        Test case to verify the comma-separated string of accounts is converted to list of accounts
+    """
+
+    @mock.patch("singer.utils.parse_args")
+    @mock.patch("tap_tiktok_ads.sync")
+    @mock.patch("tap_tiktok_ads.TikTokClient")
+    def test_accounts_list(self, mocked_TikTokClient, mocked_sync, mocked_parse_args):
+
+        # create config file
+        config = {
+            "start_date": "2022-01-01T00:00:00Z",
+            "user_agent": "tap-tiktok-ads <api_user_email@your_company.com>",
+            "access_token": "test_access_token",
+            "accounts": "1,2, 3"
+        }
+
+        # mock TikTokClient
+        mocked_TikTokClient.side_effect = MockTikTokClient
+        # mock singer.parse_args
+        mocked_parse_args.return_value = get_args(config)
+
+        # function call
+        main()
+
+        # get arguments passed during calling "sync" function
+        args, kwargs = mocked_sync.call_args
+        # get config file with which "sync" funcition is called
+        actual_config = args[1]
+
+        # create expected config containing list of accounts
+        expected_config = copy.deepcopy(config)
+        expected_config["accounts"] = [1, 2, 3]
+
+        # verify the comma-separated string of accounts is converted to list of accounts
+        self.assertEqual(actual_config, expected_config)

--- a/tests/unittests/test_accounts_list.py
+++ b/tests/unittests/test_accounts_list.py
@@ -85,9 +85,35 @@ class TestAccountsList(unittest.TestCase):
         mocked_parse_args.return_value = get_args(config)
 
         # verify we raise error when empty "accounts" is passed
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(Exception) as e:
             # function call
             main()
 
         # verify the error message
-        self.assertTrue("Please provide atleast 1 Account ID" in str(e.exception))
+        self.assertTrue(str(e.exception), "Please provide atleast 1 Account ID.")
+
+    @mock.patch("singer.utils.parse_args")
+    @mock.patch("tap_tiktok_ads.sync")
+    @mock.patch("tap_tiktok_ads.TikTokClient")
+    def test_invlaid_accounts_list(self, mocked_TikTokClient, mocked_sync, mocked_parse_args):
+
+        # create config file
+        config = {
+            "start_date": "2022-01-01T00:00:00Z",
+            "user_agent": "tap-tiktok-ads <api_user_email@your_company.com>",
+            "access_token": "test_access_token",
+            "accounts": "1a"
+        }
+
+        # mock TikTokClient
+        mocked_TikTokClient.side_effect = MockTikTokClient
+        # mock singer.parse_args
+        mocked_parse_args.return_value = get_args(config)
+
+        # verify we raise error when invlaid "accounts" is passed
+        with self.assertRaises(Exception) as e:
+            # function call
+            main()
+
+        # verify the error message
+        self.assertEqual(str(e.exception), "Provided list of account IDs contains invalid IDs. Kindly check your Account IDs.")

--- a/tests/unittests/test_transform_ad_insights_records.py
+++ b/tests/unittests/test_transform_ad_insights_records.py
@@ -1,0 +1,369 @@
+import unittest
+from tap_tiktok_ads.streams import transform_ad_insights_records
+
+class TestDictMerging(unittest.TestCase):
+    """
+        Test cases to verify the merging of 2 dicts
+    """
+
+    def test_transform_ad_insights_records(self):
+        """
+            Test case to verify the 2 dicts 'metrics' and 'dimensions' are merged into single dict
+        """
+
+        # mocked records
+        records = [
+            {
+                "metrics": {
+                    "rec1_k1": "rec1_v1",
+                    "rec1_k2": "rec1_v2"
+                },
+                "dimensions": {
+                    "rec1_k3": "rec1_v3",
+                    "rec1_k4": "rec1_v4"
+                }
+            },
+            {
+                "metrics": {
+                    "rec2_k1": "rec2_v1",
+                    "rec2_k2": "rec2_v2"
+                },
+                "dimensions": {
+                    "rec2_k3": "rec2_v3",
+                    "rec2_k4": "rec2_v4"
+                }
+            }
+        ]
+
+        # function call
+        actual_records = transform_ad_insights_records(records)
+
+        # create expected record as merged values of 'metrics' and 'dimensions'
+        expected_records = [
+            {
+                "rec1_k1": "rec1_v1",
+                "rec1_k2": "rec1_v2",
+                "rec1_k3": "rec1_v3",
+                "rec1_k4": "rec1_v4"
+            },
+            {
+                "rec2_k1": "rec2_v1",
+                "rec2_k2": "rec2_v2",
+                "rec2_k3": "rec2_v3",
+                "rec2_k4": "rec2_v4"
+            }
+        ]
+        # verify the records
+        self.assertEqual(actual_records, expected_records)
+
+    def test_transform_ad_insights_records_with_secondary_goal_result(self):
+        """
+            Test case to verify the 2 dicts 'metrics' and 'dimensions' are merged into single dict with 'secondary_goal_result'
+        """
+
+        # mocked records
+        records = [
+            {
+                "metrics": {
+                    "rec1_k1": "rec1_v1",
+                    "rec1_k2": "rec1_v2",
+                    "secondary_goal_result": "test"
+                },
+                "dimensions": {
+                    "rec1_k3": "rec1_v3",
+                    "rec1_k4": "rec1_v4"
+                }
+            },
+            {
+                "metrics": {
+                    "rec2_k1": "rec2_v1",
+                    "rec2_k2": "rec2_v2"
+                },
+                "dimensions": {
+                    "rec2_k3": "rec2_v3",
+                    "rec2_k4": "rec2_v4"
+                }
+            }
+        ]
+
+        # function call
+        actual_records = transform_ad_insights_records(records)
+
+        # create expected record as merged values of 'metrics' and 'dimensions' with 'secondary_goal_result'
+        expected_records = [
+            {
+                "rec1_k1": "rec1_v1",
+                "rec1_k2": "rec1_v2",
+                "rec1_k3": "rec1_v3",
+                "rec1_k4": "rec1_v4",
+                "secondary_goal_result": "test"
+            },
+            {
+                "rec2_k1": "rec2_v1",
+                "rec2_k2": "rec2_v2",
+                "rec2_k3": "rec2_v3",
+                "rec2_k4": "rec2_v4"
+            }
+        ]
+        # verify the records
+        self.assertEqual(actual_records, expected_records)
+
+    def test_transform_ad_insights_records_with_secondary_goal_result_None(self):
+        """
+            Test case to verify the 2 dicts 'metrics' and 'dimensions' are merged into single dict with 'secondary_goal_result' as '-'
+        """
+
+        # mocked records
+        records = [
+            {
+                "metrics": {
+                    "rec1_k1": "rec1_v1",
+                    "rec1_k2": "rec1_v2",
+                    "secondary_goal_result": "-"
+                },
+                "dimensions": {
+                    "rec1_k3": "rec1_v3",
+                    "rec1_k4": "rec1_v4"
+                }
+            },
+            {
+                "metrics": {
+                    "rec2_k1": "rec2_v1",
+                    "rec2_k2": "rec2_v2"
+                },
+                "dimensions": {
+                    "rec2_k3": "rec2_v3",
+                    "rec2_k4": "rec2_v4"
+                }
+            }
+        ]
+
+        # function call
+        actual_records = transform_ad_insights_records(records)
+
+        # create expected record as merged values of 'metrics' and 'dimensions' with 'secondary_goal_result'
+        expected_records = [
+            {
+                "rec1_k1": "rec1_v1",
+                "rec1_k2": "rec1_v2",
+                "rec1_k3": "rec1_v3",
+                "rec1_k4": "rec1_v4",
+                "secondary_goal_result": None
+            },
+            {
+                "rec2_k1": "rec2_v1",
+                "rec2_k2": "rec2_v2",
+                "rec2_k3": "rec2_v3",
+                "rec2_k4": "rec2_v4"
+            }
+        ]
+        # verify the records
+        self.assertEqual(actual_records, expected_records)
+
+    def test_transform_ad_insights_records_with_cost_per_secondary_goal_result(self):
+        """
+            Test case to verify the 2 dicts 'metrics' and 'dimensions' are merged into single dict with 'cost_per_secondary_goal_result'
+        """
+
+        # mocked records
+        records = [
+            {
+                "metrics": {
+                    "rec1_k1": "rec1_v1",
+                    "rec1_k2": "rec1_v2",
+                    "cost_per_secondary_goal_result": "test"
+                },
+                "dimensions": {
+                    "rec1_k3": "rec1_v3",
+                    "rec1_k4": "rec1_v4"
+                }
+            },
+            {
+                "metrics": {
+                    "rec2_k1": "rec2_v1",
+                    "rec2_k2": "rec2_v2"
+                },
+                "dimensions": {
+                    "rec2_k3": "rec2_v3",
+                    "rec2_k4": "rec2_v4"
+                }
+            }
+        ]
+
+        # function call
+        actual_records = transform_ad_insights_records(records)
+
+        # create expected record as merged values of 'metrics' and 'dimensions' with 'cost_per_secondary_goal_result'
+        expected_records = [
+            {
+                "rec1_k1": "rec1_v1",
+                "rec1_k2": "rec1_v2",
+                "rec1_k3": "rec1_v3",
+                "rec1_k4": "rec1_v4",
+                "cost_per_secondary_goal_result": "test"
+            },
+            {
+                "rec2_k1": "rec2_v1",
+                "rec2_k2": "rec2_v2",
+                "rec2_k3": "rec2_v3",
+                "rec2_k4": "rec2_v4"
+            }
+        ]
+        # verify the records
+        self.assertEqual(actual_records, expected_records)
+
+    def test_transform_ad_insights_records_with_cost_per_secondary_goal_result_None(self):
+        """
+            Test case to verify the 2 dicts 'metrics' and 'dimensions' are merged into single dict with 'cost_per_secondary_goal_result' as '-'
+        """
+
+        # mocked records
+        records = [
+            {
+                "metrics": {
+                    "rec1_k1": "rec1_v1",
+                    "rec1_k2": "rec1_v2",
+                    "cost_per_secondary_goal_result": "-"
+                },
+                "dimensions": {
+                    "rec1_k3": "rec1_v3",
+                    "rec1_k4": "rec1_v4"
+                }
+            },
+            {
+                "metrics": {
+                    "rec2_k1": "rec2_v1",
+                    "rec2_k2": "rec2_v2"
+                },
+                "dimensions": {
+                    "rec2_k3": "rec2_v3",
+                    "rec2_k4": "rec2_v4"
+                }
+            }
+        ]
+
+        # function call
+        actual_records = transform_ad_insights_records(records)
+
+        # create expected record as merged values of 'metrics' and 'dimensions' with 'cost_per_secondary_goal_result'
+        expected_records = [
+            {
+                "rec1_k1": "rec1_v1",
+                "rec1_k2": "rec1_v2",
+                "rec1_k3": "rec1_v3",
+                "rec1_k4": "rec1_v4",
+                "cost_per_secondary_goal_result": None
+            },
+            {
+                "rec2_k1": "rec2_v1",
+                "rec2_k2": "rec2_v2",
+                "rec2_k3": "rec2_v3",
+                "rec2_k4": "rec2_v4"
+            }
+        ]
+        # verify the records
+        self.assertEqual(actual_records, expected_records)
+
+    def test_transform_ad_insights_records_with_secondary_goal_result_rate(self):
+        """
+            Test case to verify the 2 dicts 'metrics' and 'dimensions' are merged into single dict with 'secondary_goal_result_rate'
+        """
+
+        # mocked records
+        records = [
+            {
+                "metrics": {
+                    "rec1_k1": "rec1_v1",
+                    "rec1_k2": "rec1_v2",
+                    "secondary_goal_result_rate": "test"
+                },
+                "dimensions": {
+                    "rec1_k3": "rec1_v3",
+                    "rec1_k4": "rec1_v4"
+                }
+            },
+            {
+                "metrics": {
+                    "rec2_k1": "rec2_v1",
+                    "rec2_k2": "rec2_v2"
+                },
+                "dimensions": {
+                    "rec2_k3": "rec2_v3",
+                    "rec2_k4": "rec2_v4"
+                }
+            }
+        ]
+
+        # function call
+        actual_records = transform_ad_insights_records(records)
+
+        # create expected record as merged values of 'metrics' and 'dimensions' with 'secondary_goal_result_rate'
+        expected_records = [
+            {
+                "rec1_k1": "rec1_v1",
+                "rec1_k2": "rec1_v2",
+                "rec1_k3": "rec1_v3",
+                "rec1_k4": "rec1_v4",
+                "secondary_goal_result_rate": "test"
+            },
+            {
+                "rec2_k1": "rec2_v1",
+                "rec2_k2": "rec2_v2",
+                "rec2_k3": "rec2_v3",
+                "rec2_k4": "rec2_v4"
+            }
+        ]
+        # verify the records
+        self.assertEqual(actual_records, expected_records)
+
+    def test_transform_ad_insights_records_with_secondary_goal_result_rate_None(self):
+        """
+            Test case to verify the 2 dicts 'metrics' and 'dimensions' are merged into single dict with 'secondary_goal_result_rate' as '-'
+        """
+
+        # mocked records
+        records = [
+            {
+                "metrics": {
+                    "rec1_k1": "rec1_v1",
+                    "rec1_k2": "rec1_v2",
+                    "secondary_goal_result_rate": "-"
+                },
+                "dimensions": {
+                    "rec1_k3": "rec1_v3",
+                    "rec1_k4": "rec1_v4"
+                }
+            },
+            {
+                "metrics": {
+                    "rec2_k1": "rec2_v1",
+                    "rec2_k2": "rec2_v2"
+                },
+                "dimensions": {
+                    "rec2_k3": "rec2_v3",
+                    "rec2_k4": "rec2_v4"
+                }
+            }
+        ]
+
+        # function call
+        actual_records = transform_ad_insights_records(records)
+
+        # create expected record as merged values of 'metrics' and 'dimensions' with 'secondary_goal_result_rate'
+        expected_records = [
+            {
+                "rec1_k1": "rec1_v1",
+                "rec1_k2": "rec1_v2",
+                "rec1_k3": "rec1_v3",
+                "rec1_k4": "rec1_v4",
+                "secondary_goal_result_rate": None
+            },
+            {
+                "rec2_k1": "rec2_v1",
+                "rec2_k2": "rec2_v2",
+                "rec2_k3": "rec2_v3",
+                "rec2_k4": "rec2_v4"
+            }
+        ]
+        # verify the records
+        self.assertEqual(actual_records, expected_records)


### PR DESCRIPTION
# Description of change
TDL-18739: Update the value types of the config params
- Updated the code to accept comma-separated values for `accounts` config param

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
