### PR TITLE
Fix sandbox compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.2.1
+ * Removed Missing Schema items from `adgroups` and `campaign` stream [#15] (https://github.com/singer-io/tap-tiktok-ads/pull/15)
+ * Fixed Bookmarking logic
+ * Fixed Compatibility with sandbox accounts
+
 
 ## 0.2.0
   * Implement request timeout [#3](https://github.com/singer-io/tap-tiktok-ads/pull/3)

--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,15 @@ from setuptools import setup
 
 setup(
     name="tap-tiktok-ads",
-    version="0.2.0",
+    version="0.2.1",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_tiktok_ads"],
     install_requires=[
-        # NB: Pin these to a more specific version for tap reliability
-        "singer-python",
-        "requests",
+        "singer-python==5.13.0",
+        "requests==2.28.2",
     ],
     extras_require={
         "test": [
@@ -20,7 +19,7 @@ setup(
             "nose"
         ],
         "dev": [
-            "ipdb==0.11"
+            "ipdb"
         ]
     },
     entry_points="""

--- a/tap_tiktok_ads/__init__.py
+++ b/tap_tiktok_ads/__init__.py
@@ -27,11 +27,10 @@ def main():
         raise Exception("Provided list of account IDs contains invalid IDs. Kindly check your Account IDs.") from None
     # update string to list in the config
     args.config['accounts'] = accounts_list
-    sandbox = True if str(args.config.get('sandbox', "false")).lower() == "true" else False
 
     with TikTokClient(access_token=args.config['access_token'],
                       advertiser_id=args.config['accounts'],
-                      sandbox=sandbox,
+                      sandbox=args.config.get('sandbox', "false"),
                       user_agent=args.config['user_agent'],
                       request_timeout=args.config.get('request_timeout')) as tik_tok_client:
 

--- a/tap_tiktok_ads/__init__.py
+++ b/tap_tiktok_ads/__init__.py
@@ -27,10 +27,11 @@ def main():
         raise Exception("Provided list of account IDs contains invalid IDs. Kindly check your Account IDs.") from None
     # update string to list in the config
     args.config['accounts'] = accounts_list
+    sandbox = True if args.config.get('sandbox', False) else False
 
     with TikTokClient(access_token=args.config['access_token'],
                       advertiser_id=args.config['accounts'],
-                      sandbox=args.config.get('sandbox', False),
+                      sandbox=sandbox,
                       user_agent=args.config['user_agent'],
                       request_timeout=args.config.get('request_timeout')) as tik_tok_client:
 

--- a/tap_tiktok_ads/__init__.py
+++ b/tap_tiktok_ads/__init__.py
@@ -27,7 +27,7 @@ def main():
         raise Exception("Provided list of account IDs contains invalid IDs. Kindly check your Account IDs.") from None
     # update string to list in the config
     args.config['accounts'] = accounts_list
-    sandbox = True if args.config.get('sandbox', False) else False
+    sandbox = True if str(args.config.get('sandbox', "false")).lower() == "true" else False
 
     with TikTokClient(access_token=args.config['access_token'],
                       advertiser_id=args.config['accounts'],

--- a/tap_tiktok_ads/client.py
+++ b/tap_tiktok_ads/client.py
@@ -45,7 +45,8 @@ class TikTokClient:
         self.__session = requests.Session()
         self.__base_url = None
         self.__verified = False
-        self.sandbox = sandbox
+        self.sandbox  = True if str(sandbox).lower() == "true" else False
+
         # base URL prefix
         self.__base_url_prefix = 'business-api'
         # if the account is sandbox, change the URL prefix

--- a/tap_tiktok_ads/client.py
+++ b/tap_tiktok_ads/client.py
@@ -107,6 +107,8 @@ class TikTokClient:
             params = {
                 "advertiser_ids": self.__advertiser_id
             }
+            if self.__base_url_prefix == 'sandbox-ads':
+                return True
             # Call the advertisers API with the account ids to check whether the accounts are valid or not.
             adv_response = self.get(path='advertiser/info/', headers=headers,
                                         params=params)

--- a/tap_tiktok_ads/client.py
+++ b/tap_tiktok_ads/client.py
@@ -45,10 +45,11 @@ class TikTokClient:
         self.__session = requests.Session()
         self.__base_url = None
         self.__verified = False
+        self.sandbox = sandbox
         # base URL prefix
         self.__base_url_prefix = 'business-api'
         # if the account is sandbox, change the URL prefix
-        if str(sandbox).lower() == 'true':
+        if self.sandbox:
             self.__base_url_prefix = 'sandbox-ads'
         self.__advertiser_id = advertiser_id
 

--- a/tap_tiktok_ads/schemas/adgroups.json
+++ b/tap_tiktok_ads/schemas/adgroups.json
@@ -574,18 +574,6 @@
         "string"
       ]
     },
-    "split_test_adgroup_ids": {
-      "type": [
-        "null",
-        "array"
-      ],
-      "items": {
-        "type": [
-          "null",
-          "integer"
-        ]
-      }
-    },
     "brand_safety": {
       "type": [
         "null",

--- a/tap_tiktok_ads/schemas/campaigns.json
+++ b/tap_tiktok_ads/schemas/campaigns.json
@@ -83,12 +83,6 @@
         "string"
       ]
     },
-    "split_test_variable": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "is_new_structure": {
       "type": [
         "null",

--- a/tap_tiktok_ads/streams.py
+++ b/tap_tiktok_ads/streams.py
@@ -170,7 +170,7 @@ def transform_ad_management_records(records, bookmark_value):
             record['is_comment_disable'] = bool(record['is_comment_disable'] == 0)
         # The `modify_time` format is different that the bookmark_value format(which is currently in TZ format),
         # hence resulted into falsy comparision. Thus, converted both to same formats.
-        if bookmark_value is None or utils.strptime_to_utc(record['modify_time']) > utils.strptime_to_utc(bookmark_value):
+        if bookmark_value is None or utils.strptime_to_utc(record['modify_time']) >= utils.strptime_to_utc(bookmark_value):
             transformed_records.append(record)
     return transformed_records
 
@@ -252,7 +252,7 @@ class Stream():
             Returns batches with start_date and end_date for the date_windowing using bookmark/start_date
         """
         if ('bookmarks' in self.state) and (stream_id in self.state['bookmarks'] and (str(advertiser_id) in self.state['bookmarks'][stream_id])):
-            start_date = parse(self.state['bookmarks'][stream_id][str(advertiser_id)]) + timedelta(days=1)
+            start_date = parse(self.state['bookmarks'][stream_id][str(advertiser_id)])
         else:
             start_date = parse(self.config['start_date'])
 

--- a/tap_tiktok_ads/sync.py
+++ b/tap_tiktok_ads/sync.py
@@ -20,11 +20,12 @@ def update_currently_syncing(state, stream_name):
 
 def sync(tik_tok_client, config, state, catalog):
 
-    sandbox_mode = False if config.get("sandbox",False) in  ("false","FALSE",False) else True
+    
     # Loop over selected streams in catalog
     selected_streams = catalog.get_selected_streams(state)
     for stream in selected_streams:
-        if sandbox_mode and stream.tap_stream_id == "advertisers":
+        if tik_tok_client.sandbox and stream.tap_stream_id == "advertisers":
+            # api for advertisers does not work with sandbox accout as the advertiserid's are invalid
             LOGGER.info("Skipping stream: %s for sandbox", stream.tap_stream_id)
             continue
         LOGGER.info("Syncing stream: %s", stream.tap_stream_id)

--- a/tap_tiktok_ads/sync.py
+++ b/tap_tiktok_ads/sync.py
@@ -19,8 +19,7 @@ def update_currently_syncing(state, stream_name):
     singer.write_state(state)
 
 def sync(tik_tok_client, config, state, catalog):
-
-    
+    """ Sync data from tap source """
     # Loop over selected streams in catalog
     selected_streams = catalog.get_selected_streams(state)
     for stream in selected_streams:

--- a/tap_tiktok_ads/sync.py
+++ b/tap_tiktok_ads/sync.py
@@ -22,7 +22,9 @@ def sync(tik_tok_client, config, state, catalog):
     # Loop over selected streams in catalog
     selected_streams = catalog.get_selected_streams(state)
     for stream in selected_streams:
-
+        if config.get("sandbox","false").lower() == "true" and stream.tap_stream_id == "advertisers":
+            LOGGER.info("Skipping stream: %s for sandbox", stream.tap_stream_id)
+            continue
         LOGGER.info("Syncing stream: %s", stream.tap_stream_id)
         update_currently_syncing(state, stream.tap_stream_id)
 

--- a/tap_tiktok_ads/sync.py
+++ b/tap_tiktok_ads/sync.py
@@ -19,10 +19,12 @@ def update_currently_syncing(state, stream_name):
     singer.write_state(state)
 
 def sync(tik_tok_client, config, state, catalog):
+
+    sandbox_mode = False if config.get("sandbox",False) in  ("false","FALSE",False) else True
     # Loop over selected streams in catalog
     selected_streams = catalog.get_selected_streams(state)
     for stream in selected_streams:
-        if config.get("sandbox","false").lower() == "true" and stream.tap_stream_id == "advertisers":
+        if sandbox_mode and stream.tap_stream_id == "advertisers":
             LOGGER.info("Skipping stream: %s for sandbox", stream.tap_stream_id)
             continue
         LOGGER.info("Syncing stream: %s", stream.tap_stream_id)

--- a/tests/base.py
+++ b/tests/base.py
@@ -56,6 +56,12 @@ class TiktokBase(unittest.TestCase):
     def expected_metadata(self):
         """Return all the data about all the streams"""
         return {
+            "advertisers": {
+                self.PRIMARY_KEYS: {"id", "create_time"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"create_time"},
+                self.OBEYS_START_DATE: True
+            },
             "ads": {
                 self.PRIMARY_KEYS: {"advertiser_id", "campaign_id", "adgroup_id", "ad_id", "modify_time"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,

--- a/tests/base.py
+++ b/tests/base.py
@@ -56,12 +56,6 @@ class TiktokBase(unittest.TestCase):
     def expected_metadata(self):
         """Return all the data about all the streams"""
         return {
-            "advertisers": {
-                self.PRIMARY_KEYS: {"id", "create_time"},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"create_time"},
-                self.OBEYS_START_DATE: True
-            },
             "ads": {
                 self.PRIMARY_KEYS: {"advertiser_id", "campaign_id", "adgroup_id", "ad_id", "modify_time"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,

--- a/tests/base.py
+++ b/tests/base.py
@@ -18,6 +18,11 @@ class TiktokBase(unittest.TestCase):
     INCREMENTAL = "INCREMENTAL"
     OBEYS_START_DATE = "obey-start-date"
 
+    unsupported_streams =  {
+            # as we are running tests on sandbox account, the api call fails for the following stream despite using the sandbox url
+            "advertisers"
+        }
+
     def tap_name(self):
         return "tap-tiktok-ads"
 

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -52,7 +52,7 @@ class TiktokAllFieldsTest(TiktokBase):
         - Verify no unexpected streams were replicated
         - Verify that more than just the automatic fields are replicated for each stream
         """
-        expected_streams = self.expected_streams()
+        expected_streams = self.expected_streams() -  {"advertisers"}
         
         # instantiate connection
         conn_id = connections.ensure_connection(self)

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -52,7 +52,7 @@ class TiktokAllFieldsTest(TiktokBase):
         - Verify no unexpected streams were replicated
         - Verify that more than just the automatic fields are replicated for each stream
         """
-        expected_streams = self.expected_streams() -  {"advertisers"}
+        expected_streams = self.expected_streams() -  self.unsupported_streams
         
         # instantiate connection
         conn_id = connections.ensure_connection(self)

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -13,7 +13,7 @@ class TiktokAutomaticFieldsTest(TiktokBase):
         - Verify that all replicated records have unique primary key values.
         """
         conn_id = connections.ensure_connection(self)
-        expected_streams = self.expected_streams()
+        expected_streams = self.expected_streams() -  {"advertisers"}
 
         # run check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -13,7 +13,7 @@ class TiktokAutomaticFieldsTest(TiktokBase):
         - Verify that all replicated records have unique primary key values.
         """
         conn_id = connections.ensure_connection(self)
-        expected_streams = self.expected_streams() -  {"advertisers"}
+        expected_streams = self.expected_streams() -  self.unsupported_streams
 
         # run check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -36,7 +36,7 @@ class TiktokBookmarksTest(TiktokBase):
         conn_id = connections.ensure_connection(self)
         runner.run_check_mode(self, conn_id)
 
-        expected_streams = self.expected_streams()
+        expected_streams = self.expected_streams()  - {"advertisers"}
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
         self.select_found_catalogs(conn_id, found_catalogs)

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -36,7 +36,7 @@ class TiktokBookmarksTest(TiktokBase):
         conn_id = connections.ensure_connection(self)
         runner.run_check_mode(self, conn_id)
 
-        expected_streams = self.expected_streams()  - {"advertisers"}
+        expected_streams = self.expected_streams()  - self.unsupported_streams
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
         self.select_found_catalogs(conn_id, found_catalogs)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -25,7 +25,7 @@ class TiktokDiscoveryTest(TiktokBase):
 
         Verify all streams have inclusion of automatic
         """
-        streams_to_test = self.expected_streams() - {"advertisers"}
+        streams_to_test = self.expected_streams() - self.unsupported_streams
 
         conn_id = connections.ensure_connection(self)
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -25,7 +25,7 @@ class TiktokDiscoveryTest(TiktokBase):
 
         Verify all streams have inclusion of automatic
         """
-        streams_to_test = self.expected_streams()
+        streams_to_test = self.expected_streams() - {"advertisers"}
 
         conn_id = connections.ensure_connection(self)
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -20,7 +20,7 @@ class TiktokPaginationTest(TiktokBase):
         """
 
         # 'advertisers' records depends on the number of accounts passed for syncing
-        expected_streams = self.expected_streams() - {"advertisers"}
+        expected_streams = self.expected_streams() - self.unsupported_streams
         conn_id = connections.ensure_connection(self)
 
         # Select all streams and all fields within streams

--- a/tests/unittests/test_base_url_prefix.py
+++ b/tests/unittests/test_base_url_prefix.py
@@ -40,7 +40,7 @@ class TestBaseURLPrefix(unittest.TestCase):
         # create config
         config = {
             "access_token": "test_access_token",
-            "sandbox": "false"
+            "sandbox": False
         }
 
         # create client

--- a/tests/unittests/test_base_url_prefix.py
+++ b/tests/unittests/test_base_url_prefix.py
@@ -40,7 +40,7 @@ class TestBaseURLPrefix(unittest.TestCase):
         # create config
         config = {
             "access_token": "test_access_token",
-            "sandbox": False
+            "sandbox": "false"
         }
 
         # create client

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -45,6 +45,9 @@ class TestSync(unittest.TestCase):
     def test_transform_ad_management_records(self):
         records = [
             {
+                'create_time': '2020-12-01T01:00:00.000000Z'
+            },
+            {
                 'create_time': '2021-01-01T01:00:00.000000Z'
             },
             {
@@ -58,6 +61,10 @@ class TestSync(unittest.TestCase):
         ]
         bookmark_value = '2021-01-01T01:00:00.000000Z'
         expected_result = [
+            {
+                'create_time': '2021-01-01T01:00:00.000000Z',
+                'modify_time': '2021-01-01T01:00:00.000000Z'
+            },
             {
                 'create_time': '2021-02-01T01:00:00.000000Z',
                 'modify_time': '2021-02-01T01:00:00.000000Z'
@@ -134,6 +141,9 @@ class TestSync(unittest.TestCase):
         stream_name = 'campaigns'
         records = [
             {
+                'create_time': '2020-12-01T01:00:00.000000Z'
+            },
+            {
                 'create_time': '2021-01-01T01:00:00.000000Z'
             },
             {
@@ -147,6 +157,10 @@ class TestSync(unittest.TestCase):
         ]
         bookmark_value = '2021-01-01T01:00:00.000000Z'
         expected_result = [
+            {
+                'create_time': '2021-01-01T01:00:00.000000Z',
+                'modify_time': '2021-01-01T01:00:00.000000Z'
+            },
             {
                 'create_time': '2021-02-01T01:00:00.000000Z',
                 'modify_time': '2021-02-01T01:00:00.000000Z'


### PR DESCRIPTION
# Description of change
Fixed Sandbox compatibility by skipping advertisers stream when running in sandbox mode, as the advertisers api fails for sandbox accounts.

 **Changes**
- Updated Integration tests for excluding advertisers stream
- Added Condition to skip advertisers stream while running sync with sandbox mode.
- PR's:
        https://github.com/singer-io/tap-tiktok-ads/pull/16
        https://github.com/singer-io/tap-tiktok-ads/pull/17

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
