### PR TITLE
[TDL-21907] fixes schema issue and bookmarking issue. 

### DIFF
--- a/tap_tiktok_ads/schemas/adgroups.json
+++ b/tap_tiktok_ads/schemas/adgroups.json
@@ -574,18 +574,6 @@
         "string"
       ]
     },
-    "split_test_adgroup_ids": {
-      "type": [
-        "null",
-        "array"
-      ],
-      "items": {
-        "type": [
-          "null",
-          "integer"
-        ]
-      }
-    },
     "brand_safety": {
       "type": [
         "null",

--- a/tap_tiktok_ads/schemas/campaigns.json
+++ b/tap_tiktok_ads/schemas/campaigns.json
@@ -83,12 +83,6 @@
         "string"
       ]
     },
-    "split_test_variable": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "is_new_structure": {
       "type": [
         "null",

--- a/tap_tiktok_ads/streams.py
+++ b/tap_tiktok_ads/streams.py
@@ -170,7 +170,7 @@ def transform_ad_management_records(records, bookmark_value):
             record['is_comment_disable'] = bool(record['is_comment_disable'] == 0)
         # The `modify_time` format is different that the bookmark_value format(which is currently in TZ format),
         # hence resulted into falsy comparision. Thus, converted both to same formats.
-        if bookmark_value is None or utils.strptime_to_utc(record['modify_time']) > utils.strptime_to_utc(bookmark_value):
+        if bookmark_value is None or utils.strptime_to_utc(record['modify_time']) >= utils.strptime_to_utc(bookmark_value):
             transformed_records.append(record)
     return transformed_records
 
@@ -252,7 +252,7 @@ class Stream():
             Returns batches with start_date and end_date for the date_windowing using bookmark/start_date
         """
         if ('bookmarks' in self.state) and (stream_id in self.state['bookmarks'] and (str(advertiser_id) in self.state['bookmarks'][stream_id])):
-            start_date = parse(self.state['bookmarks'][stream_id][str(advertiser_id)]) + timedelta(days=1)
+            start_date = parse(self.state['bookmarks'][stream_id][str(advertiser_id)])
         else:
             start_date = parse(self.config['start_date'])
 

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -43,10 +43,9 @@ class TestSync(unittest.TestCase):
         self.assertEqual(get_date_batches(start_date, end_date), expected_result)
 
     def test_transform_ad_management_records(self):
-        import pdb; pdb.set_trace()
         records = [
             {
-                'create_time': '2021-12-01T01:00:00.000000Z'
+                'create_time': '2020-12-01T01:00:00.000000Z'
             },
             {
                 'create_time': '2021-01-01T01:00:00.000000Z'
@@ -63,7 +62,8 @@ class TestSync(unittest.TestCase):
         bookmark_value = '2021-01-01T01:00:00.000000Z'
         expected_result = [
             {
-                'create_time': '2021-01-01T01:00:00.000000Z'
+                'create_time': '2021-01-01T01:00:00.000000Z',
+                'modify_time': '2021-01-01T01:00:00.000000Z'
             },
             {
                 'create_time': '2021-02-01T01:00:00.000000Z',
@@ -141,6 +141,9 @@ class TestSync(unittest.TestCase):
         stream_name = 'campaigns'
         records = [
             {
+                'create_time': '2020-12-01T01:00:00.000000Z'
+            },
+            {
                 'create_time': '2021-01-01T01:00:00.000000Z'
             },
             {
@@ -154,6 +157,10 @@ class TestSync(unittest.TestCase):
         ]
         bookmark_value = '2021-01-01T01:00:00.000000Z'
         expected_result = [
+            {
+                'create_time': '2021-01-01T01:00:00.000000Z',
+                'modify_time': '2021-01-01T01:00:00.000000Z'
+            },
             {
                 'create_time': '2021-02-01T01:00:00.000000Z',
                 'modify_time': '2021-02-01T01:00:00.000000Z'

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -43,7 +43,11 @@ class TestSync(unittest.TestCase):
         self.assertEqual(get_date_batches(start_date, end_date), expected_result)
 
     def test_transform_ad_management_records(self):
+        import pdb; pdb.set_trace()
         records = [
+            {
+                'create_time': '2021-12-01T01:00:00.000000Z'
+            },
             {
                 'create_time': '2021-01-01T01:00:00.000000Z'
             },
@@ -58,6 +62,9 @@ class TestSync(unittest.TestCase):
         ]
         bookmark_value = '2021-01-01T01:00:00.000000Z'
         expected_result = [
+            {
+                'create_time': '2021-01-01T01:00:00.000000Z'
+            },
             {
                 'create_time': '2021-02-01T01:00:00.000000Z',
                 'modify_time': '2021-02-01T01:00:00.000000Z'


### PR DESCRIPTION
# Description of change
Removed Missing fields from schema, as they are no longer available in api response for `campaign` and `adgroup` stream
Fixed Bookmarking issue TDL-21907

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
